### PR TITLE
Feat/mechanic show

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
   gem 'pry'
   gem 'simplecov'
   gem 'shoulda-matchers', '~> 3.1'
+  gem 'orderly'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    orderly (0.1.1)
+      capybara (>= 1.1)
+      rspec (>= 2.14)
     pg (1.4.3)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -141,6 +144,10 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.5.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.0)
@@ -213,6 +220,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)
+  orderly
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.11)

--- a/app/controllers/mechanics_controller.rb
+++ b/app/controllers/mechanics_controller.rb
@@ -2,4 +2,8 @@ class MechanicsController < ApplicationController
   def index
     @mechanics = Mechanic.all
   end
+
+  def show
+    @mechanic = Mechanic.find(params[:id])
+  end
 end

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -1,7 +1,6 @@
 class Ride < ApplicationRecord
   validates :name, presence: true
   validates :thrill_rating, presence: true
-  validates :open, presence: true
 
   belongs_to :amusement_park
 

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -6,4 +6,12 @@ class Ride < ApplicationRecord
 
   has_many :ride_mechanics
   has_many :mechanics, through: :ride_mechanics
+
+  def self.open_rides
+    where(open: true)
+  end
+
+  def self.order_by_most_thrills
+    order(thrill_rating: :desc)
+  end
 end

--- a/app/views/mechanics/show.html.erb
+++ b/app/views/mechanics/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @mechanic.name %></h1>
 <h2>Years of Experience: <%= @mechanic.years_experience %> </h2>
-<h3>Open Rides: </h3>
-<% @mechanic.rides.each do |ride| %>
-  <p><%= ride.name %> - Thrill Rating: <%=ride.thrill_rating %></p>
+<h3>Rides Worked On (Open Rides Only): </h3>
+<% @mechanic.rides.open_rides.order_by_most_thrills.each do |ride| %>
+  <p>*<%= ride.name %> - Thrill Rating: <%=ride.thrill_rating %></p>
 <% end %>

--- a/app/views/mechanics/show.html.erb
+++ b/app/views/mechanics/show.html.erb
@@ -1,0 +1,6 @@
+<h1><%= @mechanic.name %></h1>
+<h2>Years of Experience: <%= @mechanic.years_experience %> </h2>
+<h3>Open Rides: </h3>
+<% @mechanic.rides.each do |ride| %>
+  <p><%= ride.name %> - Thrill Rating: <%=ride.thrill_rating %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/mechanics', to: 'mechanics#index'
+  get '/mechanics/:id', to: 'mechanics#show'
 end

--- a/spec/features/mechanics/show_spec.rb
+++ b/spec/features/mechanics/show_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe 'Mechanic Show Page' do
 
       it 'I only see rides that are open' do
         visit "/mechanics/#{@mechanic1.id}"
-
+        save_and_open_page
         expect(page).to have_content(@hurler.name)
         expect(page).to have_content(@scrambler.name)
         expect(page).to have_content(@coaster1.name)
-        
+
         expect(page).to_not have_content(@ferris.name)
         expect(page).to_not have_content(@coaster2.name)
       end

--- a/spec/features/mechanics/show_spec.rb
+++ b/spec/features/mechanics/show_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'Mechanic Show Page' do
+  before :each do
+    @six_flags = AmusementPark.create!(name: 'Six Flags', admission_cost: 75)
+
+    @hurler = @six_flags.rides.create!(name: 'The Hurler', thrill_rating: 7, open: true)
+    @scrambler = @six_flags.rides.create!(name: 'The Scrambler', thrill_rating: 4, open: true)
+    @ferris = @six_flags.rides.create!(name: 'Ferris Wheel', thrill_rating: 7, open: false)
+    @coaster1 = @six_flags.rides.create!(name: 'The Batman Coaster', thrill_rating: 8, open: true)
+    @coaster2 = @six_flags.rides.create!(name: 'Superman', thrill_rating: 10, open: false)
+
+    @mechanic1 = Mechanic.create!(name: "Cooter Davenport", years_experience: 25)
+    @mechanic2 = Mechanic.create!(name: "Fonzie", years_experience: 18)
+
+    RideMechanic.create!(mechanic_id: @mechanic1.id, ride_id: @hurler.id)
+    RideMechanic.create!(mechanic_id: @mechanic1.id, ride_id: @scrambler.id)
+    RideMechanic.create!(mechanic_id: @mechanic1.id, ride_id: @ferris.id)
+    RideMechanic.create!(mechanic_id: @mechanic1.id, ride_id: @coaster1.id)
+    RideMechanic.create!(mechanic_id: @mechanic1.id, ride_id: @coaster2.id)
+    RideMechanic.create!(mechanic_id: @mechanic2.id, ride_id: @ferris.id)
+  end
+
+  describe 'As a user' do
+    describe 'When I visit a mechanic show page' do
+      it 'I see their name, years of experience, and the names of the rides theyre working on' do
+        visit "/mechanics/#{@mechanic1.id}"
+
+        expect(page).to have_content(@mechanic1.name)
+        expect(page).to have_content(@mechanic1.years_experience)
+        expect(page).to have_content(@hurler.name)
+        expect(page).to have_content(@scrambler.name)
+        expect(page).to have_content(@coaster1.name)
+
+        expect(page).to_not have_content(@mechanic2.name)
+      end
+
+      it 'I only see rides that are open' do
+        visit "/mechanics/#{@mechanic1.id}"
+
+        expect(page).to have_content(@hurler.name)
+        expect(page).to have_content(@scrambler.name)
+        expect(page).to have_content(@coaster1.name)
+        
+        expect(page).to_not have_content(@ferris.name)
+        expect(page).to_not have_content(@coaster2.name)
+      end
+
+      it 'The rides are listed by thrill rating in descending order (most thrills first)' do
+        visit "/mechanics/#{@mechanic1.id}"
+
+        expect(@coaster1.name).to appear_before(@hurler.name)
+        expect(@hurler.name).to appear_before(@scrambler.name)
+      end
+    end
+  end
+end

--- a/spec/features/mechanics/show_spec.rb
+++ b/spec/features/mechanics/show_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Mechanic Show Page' do
 
       it 'I only see rides that are open' do
         visit "/mechanics/#{@mechanic1.id}"
-        save_and_open_page
+        
         expect(page).to have_content(@hurler.name)
         expect(page).to have_content(@scrambler.name)
         expect(page).to have_content(@coaster1.name)

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -10,6 +10,5 @@ RSpec.describe Ride, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:thrill_rating) }
-    it { should validate_presence_of(:open) }
   end
 end

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -11,4 +11,28 @@ RSpec.describe Ride, type: :model do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:thrill_rating) }
   end
+
+  describe 'class methods' do
+    before :each do
+      @six_flags = AmusementPark.create!(name: 'Six Flags', admission_cost: 75)
+
+      @hurler = @six_flags.rides.create!(name: 'The Hurler', thrill_rating: 7, open: true)
+      @scrambler = @six_flags.rides.create!(name: 'The Scrambler', thrill_rating: 4, open: true)
+      @ferris = @six_flags.rides.create!(name: 'Ferris Wheel', thrill_rating: 6, open: false)
+      @coaster1 = @six_flags.rides.create!(name: 'The Batman Coaster', thrill_rating: 8, open: true)
+      @coaster2 = @six_flags.rides.create!(name: 'Superman', thrill_rating: 10, open: false)
+    end
+
+    describe '.open_rides' do
+      it 'can list all rides that are open' do
+        expect(Ride.open_rides).to eq([@hurler, @scrambler, @coaster1])
+      end
+    end
+
+    describe '.order_by_most_thrills' do
+      it 'can order all rides from highest thrill rating to lowest' do
+        expect(Ride.order_by_most_thrills).to eq([@coaster2, @coaster1, @hurler, @ferris, @scrambler])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Completes User Story 2
Mechanic Show Page

As a user,
When I visit a mechanic show page
I see their name, years of experience, and the names of rides they’re working on
And I only see rides that are open
And the rides are listed by thrill rating in descending order (most thrills first)