### PR TITLE
Feat/add ride to mechanic

### DIFF
--- a/app/controllers/mechanics_controller.rb
+++ b/app/controllers/mechanics_controller.rb
@@ -6,4 +6,10 @@ class MechanicsController < ApplicationController
   def show
     @mechanic = Mechanic.find(params[:id])
   end
+
+  def update
+    @mechanic = Mechanic.find(params[:id])
+    RideMechanic.create(ride_id: params[:add_ride], mechanic_id: params[:id])
+    render :show
+  end
 end

--- a/app/views/mechanics/show.html.erb
+++ b/app/views/mechanics/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @mechanic.name %></h1>
 <h2>Years of Experience: <%= @mechanic.years_experience %> </h2>
-<h3>Rides Worked On (Open Rides Only): </h3>
+<h3>Current Rides they're working on: </h3>
 <% @mechanic.rides.open_rides.order_by_most_thrills.each do |ride| %>
-  <p>*<%= ride.name %> - Thrill Rating: <%=ride.thrill_rating %></p>
+  <p><%= ride.name %> - Thrill Rating: <%=ride.thrill_rating %></p>
 <% end %>

--- a/app/views/mechanics/show.html.erb
+++ b/app/views/mechanics/show.html.erb
@@ -4,3 +4,12 @@
 <% @mechanic.rides.open_rides.order_by_most_thrills.each do |ride| %>
   <p><%= ride.name %> - Thrill Rating: <%=ride.thrill_rating %></p>
 <% end %>
+
+<h3>Add a ride to workload</h3>
+<%= form_with url: "/mechanics/#{@mechanic.id}/", method: :patch, local: true do |f| %>
+
+<%= f.label :add_ride, "Ride ID" %>
+<%= f.number_field :add_ride %>
+
+<%= f.submit "Submit"%>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/mechanics', to: 'mechanics#index'
   get '/mechanics/:id', to: 'mechanics#show'
+  patch '/mechanics/:id', to: 'mechanics#update'
 end

--- a/spec/features/mechanics/update_spec.rb
+++ b/spec/features/mechanics/update_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'Add a Ride to a Mechanic' do
+  before :each do
+    @six_flags = AmusementPark.create!(name: 'Six Flags', admission_cost: 75)
+
+    @hurler = @six_flags.rides.create!(name: 'The Hurler', thrill_rating: 7, open: true)
+    @scrambler = @six_flags.rides.create!(name: 'The Scrambler', thrill_rating: 4, open: true)
+    @coaster1 = @six_flags.rides.create!(name: 'The Batman Coaster', thrill_rating: 8, open: true)
+
+    @mechanic1 = Mechanic.create!(name: "Cooter Davenport", years_experience: 25)
+
+    RideMechanic.create!(mechanic_id: @mechanic1.id, ride_id: @hurler.id)
+    RideMechanic.create!(mechanic_id: @mechanic1.id, ride_id: @scrambler.id)
+  end
+
+  describe 'As a user' do
+    describe 'When I go to a mechanics show page' do
+      it 'I see a form to add a ride to their workload' do
+        visit "/mechanics/#{@mechanic1.id}"
+
+        expect(page).to have_content(@hurler.name)
+        expect(page).to have_content(@scrambler.name)
+        expect(page).to_not have_content(@coaster1.name)
+
+        expect(find('form')).to have_content('Ride ID')
+      end
+    end
+
+    describe 'When I fill in that field with an id of an existing ride and hit submit' do
+      it 'I am taken back to that mechanics show page' do
+        visit "/mechanics/#{@mechanic1.id}"
+
+        fill_in 'ride_id', with: "#{@coaster1.id}"
+        click_button 'Submit'
+
+        expect(current_path).to eq("/mechanics/#{@mechanic1.id}")
+      end
+
+      it 'I see the name of that newly added ride on this mechanics show page' do
+        visit "/mechanics/#{@mechanic1.id}"
+
+        fill_in 'ride_id', with: "#{@coaster1.id}"
+        click_button 'Submit'
+
+        expect(page).to have_content(@hurler.name)
+        expect(page).to have_content(@scrambler.name)
+        expect(page).to have_content(@coaster1.name)
+      end
+    end
+  end
+end

--- a/spec/features/mechanics/update_spec.rb
+++ b/spec/features/mechanics/update_spec.rb
@@ -31,16 +31,16 @@ RSpec.describe 'Add a Ride to a Mechanic' do
       it 'I am taken back to that mechanics show page' do
         visit "/mechanics/#{@mechanic1.id}"
 
-        fill_in 'ride_id', with: "#{@coaster1.id}"
+        fill_in 'add_ride', with: "#{@coaster1.id}"
         click_button 'Submit'
 
-        expect(current_path).to eq("/mechanics/#{@mechanic1.id}")
+        expect(current_path).to eq("/mechanics/#{@mechanic1.id}/")
       end
 
       it 'I see the name of that newly added ride on this mechanics show page' do
         visit "/mechanics/#{@mechanic1.id}"
 
-        fill_in 'ride_id', with: "#{@coaster1.id}"
+        fill_in 'add_ride', with: "#{@coaster1.id}"
         click_button 'Submit'
 
         expect(page).to have_content(@hurler.name)


### PR DESCRIPTION
Completes User Story 3:
Add a Ride to a Mechanic

As a user,
When I go to a mechanics show page
I see a form to add a ride to their workload
When I fill in that field with an id of an existing ride and hit submit
I’m taken back to that mechanic's show page
And I see the name of that newly added ride on this mechanics show page

Ex:
Mechanic: Kara Smith
Years of Experience: 11

Current rides they’re working on:
The Frog Hopper
Fahrenheit
The Kiss Raise

Add a ride to workload:
Ride Id: _pretend_this_is_a_textfield_
Submit