### PR TITLE
Feat/amusement park show

### DIFF
--- a/app/controllers/amusement_parks_controller.rb
+++ b/app/controllers/amusement_parks_controller.rb
@@ -1,4 +1,5 @@
 class AmusementParksController < ApplicationController
   def show
+    @amusement_park = AmusementPark.find(params[:id])
   end
 end

--- a/app/controllers/amusement_parks_controller.rb
+++ b/app/controllers/amusement_parks_controller.rb
@@ -1,0 +1,4 @@
+class AmusementParksController < ApplicationController
+  def show
+  end
+end

--- a/app/models/amusement_park.rb
+++ b/app/models/amusement_park.rb
@@ -1,6 +1,6 @@
 class AmusementPark < ApplicationRecord
   validates :name, presence: true
   validates :admission_cost, presence: true
-  
+
   has_many :rides
 end

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -14,4 +14,12 @@ class Ride < ApplicationRecord
   def self.order_by_most_thrills
     order(thrill_rating: :desc)
   end
+
+  def self.order_by_name
+    order(:name)
+  end
+
+  def self.average_thrill_rating
+    average(:thrill_rating)
+  end
 end

--- a/app/views/amusement_parks/show.html.erb
+++ b/app/views/amusement_parks/show.html.erb
@@ -1,0 +1,8 @@
+<h1><%= @amusement_park.name %></h1>
+<h2>Admissions: <%= @amusement_park.admission_cost %></h2>
+<h3>Rides: </h3>
+<% @amusement_park.rides.order_by_name.each do |ride| %>
+ <p><%= ride.name %></p>
+<% end %>
+
+<h4>Average Thrill Rating of Rides: <%= @amusement_park.rides.average_thrill_rating%>/10</h4>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
   get '/mechanics', to: 'mechanics#index'
   get '/mechanics/:id', to: 'mechanics#show'
   patch '/mechanics/:id', to: 'mechanics#update'
+
+  get '/amusement_parks/:id', to: 'amusement_parks#show'
 end

--- a/spec/features/amusement_parks/show_spec.rb
+++ b/spec/features/amusement_parks/show_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'Amusement Park Show page' do
+  before :each do
+    @six_flags = AmusementPark.create!(name: 'Six Flags', admission_cost: 75)
+    @universal = AmusementPark.create!(name: 'Universal Studios', admission_cost: 80)
+
+    @hurler = @six_flags.rides.create!(name: 'The Hurler', thrill_rating: 7, open: true)
+    @scrambler = @six_flags.rides.create!(name: 'The Scrambler', thrill_rating: 4, open: true)
+    @ferris = @six_flags.rides.create!(name: 'Ferris Wheel', thrill_rating: 7, open: false)
+
+    @jaws = @universal.rides.create!(name: 'Jaws', thrill_rating: 5, open: true)
+  end
+
+  describe 'As a visitor' do
+    describe 'When I visit an amusement parks show page' do
+      it 'I see the name and price of admissions for that amusement park' do
+        visit "amusement_parks/#{@six_flags.id}"
+
+        expect(page).to have_content(@six_flags.name)
+        expect(page).to have_content(@six_flags.admission_cost)
+        expect(page).to_not have_content(@universal.name)
+        expect(page).to_not have_content(@universal.admission_cost)
+      end
+
+      it 'I see the names of all the rides that are at that theme park listed in alphabetical order' do
+        visit "amusement_parks/#{@six_flags.id}"
+
+        expect(@ferris.name).to appear_before(@hurler.name)
+        expect(@hurler.name).to appear_before(@scrambler.name)
+      end
+
+      it 'I see the average thrill rating of this amusement parks rides' do
+        visit "amusement_parks/#{@six_flags.id}"
+
+        expect(page).to have_content("Average Thrill Rating of Rides: 6/10")
+      end
+    end
+  end
+end

--- a/spec/features/amusement_parks/show_spec.rb
+++ b/spec/features/amusement_parks/show_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Amusement Park Show page' do
   describe 'As a visitor' do
     describe 'When I visit an amusement parks show page' do
       it 'I see the name and price of admissions for that amusement park' do
-        visit "amusement_parks/#{@six_flags.id}"
+        visit "/amusement_parks/#{@six_flags.id}"
 
         expect(page).to have_content(@six_flags.name)
         expect(page).to have_content(@six_flags.admission_cost)
@@ -24,17 +24,17 @@ RSpec.describe 'Amusement Park Show page' do
       end
 
       it 'I see the names of all the rides that are at that theme park listed in alphabetical order' do
-        visit "amusement_parks/#{@six_flags.id}"
+        visit "/amusement_parks/#{@six_flags.id}"
 
         expect(@ferris.name).to appear_before(@hurler.name)
         expect(@hurler.name).to appear_before(@scrambler.name)
       end
 
       it 'I see the average thrill rating of this amusement parks rides' do
-        visit "amusement_parks/#{@six_flags.id}"
+        visit "/amusement_parks/#{@six_flags.id}"
 
-        expect(page).to have_content("Average Thrill Rating of Rides: 6/10")
+        expect(page).to have_content("Average Thrill Rating of Rides: 6.0/10")
       end
     end
+    end
   end
-end

--- a/spec/models/amusement_park_spec.rb
+++ b/spec/models/amusement_park_spec.rb
@@ -9,4 +9,26 @@ RSpec.describe AmusementPark, type: :model do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:admission_cost) }
   end
+
+  describe 'class methods' do
+    before :each do
+      @six_flags = AmusementPark.create!(name: 'Six Flags', admission_cost: 75)
+
+      @hurler = @six_flags.rides.create!(name: 'The Hurler', thrill_rating: 7, open: true)
+      @scrambler = @six_flags.rides.create!(name: 'The Scrambler', thrill_rating: 4, open: true)
+      @ferris = @six_flags.rides.create!(name: 'Ferris Wheel', thrill_rating: 7, open: false)
+    end
+
+    describe '.rides_ordered_alphabetically' do
+      it 'can order an amusement parks rides alphabetically' do
+        expect(AmusementPark.rides_ordered_alphabetically).to eq([@ferris, @hurler, @scrambler])
+      end
+    end
+
+    describe '.average_thrill_rating' do
+      it 'can calculate the average thrill rating of an amusement parks rides' do
+        expect(AmusementPark.average_thrill_rating).to eq(6)
+      end
+    end
+  end
 end

--- a/spec/models/amusement_park_spec.rb
+++ b/spec/models/amusement_park_spec.rb
@@ -9,26 +9,4 @@ RSpec.describe AmusementPark, type: :model do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:admission_cost) }
   end
-
-  describe 'class methods' do
-    before :each do
-      @six_flags = AmusementPark.create!(name: 'Six Flags', admission_cost: 75)
-
-      @hurler = @six_flags.rides.create!(name: 'The Hurler', thrill_rating: 7, open: true)
-      @scrambler = @six_flags.rides.create!(name: 'The Scrambler', thrill_rating: 4, open: true)
-      @ferris = @six_flags.rides.create!(name: 'Ferris Wheel', thrill_rating: 7, open: false)
-    end
-
-    describe '.rides_ordered_alphabetically' do
-      it 'can order an amusement parks rides alphabetically' do
-        expect(AmusementPark.rides_ordered_alphabetically).to eq([@ferris, @hurler, @scrambler])
-      end
-    end
-
-    describe '.average_thrill_rating' do
-      it 'can calculate the average thrill rating of an amusement parks rides' do
-        expect(AmusementPark.average_thrill_rating).to eq(6)
-      end
-    end
-  end
 end

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -34,5 +34,17 @@ RSpec.describe Ride, type: :model do
         expect(Ride.order_by_most_thrills).to eq([@coaster2, @coaster1, @hurler, @ferris, @scrambler])
       end
     end
+
+    describe '.order_by_name' do
+      it 'can order an amusement parks rides alphabetically' do
+        expect(Ride.order(:name)).to eq([@ferris, @coaster2, @coaster1, @hurler, @scrambler])
+      end
+    end
+
+    describe '.average_thrill_rating' do
+      it 'can calculate the average thrill rating of an amusement parks rides' do
+        expect(Ride.average_thrill_rating).to eq(7)
+      end
+    end
   end
 end


### PR DESCRIPTION
Complete Extension
Extension - Amusement Park Show page

As a visitor,
When I visit an amusement park’s show page
I see the name and price of admissions for that amusement park
And I see the names of all the rides that are at that theme park listed in alphabetical order
And I see the average thrill rating of this amusement park’s rides
Ex: Hershey Park
   Admissions: $50.00

   Rides:
          1. Lightning Racer
          2. Storm Runner
          3. The Great Bear
   Average Thrill Rating of Rides: 7.8/10

Note: You may have to make new migrations for this story